### PR TITLE
SVG icon support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,4 @@ dist
 
 # OSX Traces
 .DS_Store
+.idea

--- a/config/webpack.config.base.js
+++ b/config/webpack.config.base.js
@@ -75,12 +75,19 @@ module.exports = (ctx) => {
     module: {
       rules: [
         {
-          test: /\.react.svg$/,
-          use: ['@svgr/webpack'],
+          test: /\.react\.svg$/,
+          use: [
+            {
+              loader: "@svgr/webpack",
+              options: {
+                icon: true,
+              },
+            },
+          ],
         },
         {
           test: /\.(png|jpe?g|gif|svg)$/i,
-          exclude: /node_modules/,
+          exclude: /node_modules|\.react\.svg$/,
           use: [
             {
               loader: "file-loader",


### PR DESCRIPTION
* add support for SVG icons, so they'll resize based on font size.
* fix webpack config to exclude `*.react.svg` files from `file-loader`.