### PR TITLE
fix: json files must not be processed by ts-loader

### DIFF
--- a/config/webpack.config.base.js
+++ b/config/webpack.config.base.js
@@ -103,7 +103,7 @@ module.exports = (ctx) => {
           use: [MiniCssExtractPlugin.loader, "css-loader", "sass-loader"],
         },
         {
-          test: /\.([tj]sx?|json)$/i,
+          test: /\.([tj]sx?)$/i,
           exclude: /node_modules/,
           use: [
             {


### PR DESCRIPTION
When building libraries with webpack, json files are handled correctly but ts-loader will complain that no sources are emitted for them. Not explicitly handling them fixes this issue.